### PR TITLE
make Pinger Response and TracePacketResult properties public

### DIFF
--- a/Sources/NetDiagnosis/Pinger+Trace.swift
+++ b/Sources/NetDiagnosis/Pinger+Trace.swift
@@ -17,9 +17,9 @@ extension Pinger {
     }
     
     public struct TracePacketResult {
-        var pingResult: PingResult
-        var hop: UInt8
-        var packetIndex: UInt8
+        public var pingResult: PingResult
+        public var hop: UInt8
+        public var packetIndex: UInt8
     }
     
     public func trace(

--- a/Sources/NetDiagnosis/Pinger.swift
+++ b/Sources/NetDiagnosis/Pinger.swift
@@ -11,12 +11,12 @@ import Foundation
 // swiftlint: disable type_body_length force_unwrapping function_body_length
 public class Pinger {
     public struct Response {
-        var len: Int
-        var from: IPAddr
-        var hopLimit: UInt8
-        var sequence: UInt16
-        var identifier: UInt16
-        var rtt: TimeInterval
+        public var len: Int
+        public var from: IPAddr
+        public var hopLimit: UInt8
+        public var sequence: UInt16
+        public var identifier: UInt16
+        public var rtt: TimeInterval
     }
     
     public enum PingResult {


### PR DESCRIPTION
It would be great to be able to access `Response` and `TracePacketResult` properties.