### PR TITLE
(fix) close socket on Pinger deinit

### DIFF
--- a/Sources/NetDiagnosis/Pinger.swift
+++ b/Sources/NetDiagnosis/Pinger.swift
@@ -56,7 +56,11 @@ public class Pinger {
         }
         try self.setReceiveHopLimit(true)
     }
-    
+
+    deinit {
+        close(sock)
+    }
+
     public func ping(
         packetSize: Int? = nil,
         hopLimit: UInt8? = nil,

--- a/Tests/NetDiagnosisTests/NetDiagnosisTests.swift
+++ b/Tests/NetDiagnosisTests/NetDiagnosisTests.swift
@@ -1,11 +1,31 @@
-//import XCTest
-//@testable import NetDiagnosis
-//
-//final class NetDiagnosisTests: XCTestCase {
-//    func testExample() throws {
-//        // This is an example of a functional test case.
-//        // Use XCTAssert and related functions to verify your tests produce the correct
-//        // results.
-//        XCTAssertEqual(NetDiagnosis().text, "Hello, World!")
-//    }
-//}
+import XCTest
+@testable import NetDiagnosis
+
+final class NetDiagnosisTests: XCTestCase {
+    func testCloseSocket() throws {
+        let addr = try XCTUnwrap(IPAddr.create("8.8.8.8", addressFamily: .ipv4))
+        var socket: Int32?
+        weak var wpinger: Pinger?
+        try {
+            let pinger = try Pinger(remoteAddr: addr)
+            wpinger = pinger
+            socket = pinger.sock
+        }()
+
+        let socketUnwrapped = try XCTUnwrap(socket)
+        XCTAssertNil(wpinger)
+
+        XCTAssertFalse(checkIfSocketIsOpen(socketUnwrapped))
+    }
+
+    /// This is not a thorough investigation if the socket is open, but should suffice for a simple test
+    private func checkIfSocketIsOpen(_ socket: Int32) -> Bool {
+        var error = 0
+        var errorLength = socklen_t(MemoryLayout<Int>.size)
+
+        if getsockopt(socket, SOL_SOCKET, SO_ERROR, &error, &errorLength) < 0 {
+            return false
+        }
+        return error == 0
+    }
+}


### PR DESCRIPTION
I ran into an issue where my system became non responsive when I was rapidly creating new Pinger objects. I realized it was because the socket was never closing, so my system literally ran out of sockets to open, so I couldn't even open a new terminal session. (Or something to this effect - ultimately too many sockets!)

Anyways, this should resolve that issue. (Includes a test that confirms it's working - to see before and after, simple comment out the deinit)